### PR TITLE
Configure threads for users to 16 and reset

### DIFF
--- a/Code/Highway/HwyAssn_HOT_TCv7.rsc
+++ b/Code/Highway/HwyAssn_HOT_TCv7.rsc
@@ -38,6 +38,14 @@ macro "HwyAssn_HOT" (Args, hwyassnarguments, timeperiod)
 	hwy_file = Args.[Hwy Name]
 	{, , netview, } = SplitPath(hwy_file)
 
+	user_threads = GetNumThreads()
+	initial_threads = user_threads
+	
+	if user_threads <> 16
+		then SetNumThreads(16)
+		else do SetNumThreads(user_threads)
+		end
+
 	// can change to "BPR" to run straight BPR function
 	hwyassntype = "BPR"
 	/*
@@ -1146,6 +1154,8 @@ new_mat = CopyMatrix(mc, {{"File Name", od_hot_matrix},
 	RunMacro("G30 File Close All")
 	datentime = GetDateandTime()
 	AppendToLogFile(1, "Exit HwyAssn_HOT: " + datentime)
+	SetNumThreads(initial_threads)
+
 	return(HOTHwyAssnOK)
 
 EndMacro

--- a/Code/Highway/HwyAssn_MMA_TCv7.rsc
+++ b/Code/Highway/HwyAssn_MMA_TCv7.rsc
@@ -33,6 +33,15 @@ Macro "HwyAssn_MMA" (Args, od_matrix, cap_field, output_bin, timeperiod)
 	hwy_file = Args.[Hwy Name]
 	{, , netview, } = SplitPath(hwy_file)
 
+	user_threads = GetNumThreads()
+	initial_threads = user_threads
+	
+	if user_threads <> 16
+		then SetNumThreads(16)
+		else do SetNumThreads(user_threads)
+		end
+	// SetNumThreads(16) // 5/12/25	 	
+
 
 	/*if timeperiod = "AMpeak" then do	
 		hwy_file = Args.[AM Peak Hwy Name]
@@ -327,6 +336,7 @@ badquit:
 quit:
 	datentime = GetDateandTime()
 	AppendToLogFile(2, "Exit HwyAssn_MMA: " + datentime)
+	SetNumThreads(initial_threads)
 	return(HwyAssnOK)
 
 endMacro


### PR DESCRIPTION
This is needed to ensure that there are matches across state DOTs, regardless of computer specifications.